### PR TITLE
Fix dataset metadata path after HuggingFace rename

### DIFF
--- a/src/physical_ai_av/dataset.py
+++ b/src/physical_ai_av/dataset.py
@@ -68,7 +68,7 @@ class PhysicalAIAVDatasetInterface(hf_interface.HfRepoInterface):
 
         self.clip_index = pd.read_parquet(self.download_file("clip_index.parquet"))
         self.sensor_presence = pd.read_parquet(
-            self.download_file("metadata/sensor_presence.parquet")
+            self.download_file("metadata/feature_presence.parquet")
         )
         self.data_collection = pd.read_parquet(
             self.download_file("metadata/data_collection.parquet")


### PR DESCRIPTION
## Summary
Updates dataset metadata path to match upstream HuggingFace dataset schema change.

## Changes
- Changed `sensor_presence.parquet` → `feature_presence.parquet` in physical_ai_av/src/physical_ai_av/dataset.py

## Context
The PhysicalAI-AV HuggingFace dataset was updated in https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles/commit/282c723cb1a336d94c4d5a2e8b2db5c6ea15e157, renaming the metadata file.

## Testing
Verified that `test_inference.py` from the Alpamayo repo now runs successfully without `IndexError`.

**Before:**
```
IndexError: list index out of range
```

**After:**
Successfully loads dataset for clip_id 030c760c-ae38-49aa-9ad8-f5650a545d26
```

Fixes #8