### PR TITLE
Update scipy version requirement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyarrow",
-    "scipy",
+    "scipy>=1.16.0",
     "tqdm",
 ]
 


### PR DESCRIPTION
After installation with `pip install physical-ai-av` on Ubuntu 24.04, I ran into this error:

```
module 'scipy.spatial.transform' has no attribute 'RigidTransform'
```

Probably because scipy version `1.11.4` released via apt package `python3-scipy` is too old and `RigidTransform` was [introduced with scipy 1.16.0](https://docs.scipy.org/doc/scipy-1.16.0/reference/generated/scipy.spatial.transform.RigidTransform.html).