### PR TITLE
docs(support): add issue templates + README support banner

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a bug report to help us improve Alpamayo
+title: "[BUG]"
+labels: "? - Needs Triage, bug"
+assignees: 'yesfandiari'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps/Code to reproduce bug**
+Follow this guide http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports to craft a minimal bug report. This helps us reproduce the issue and resolve it more quickly.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment overview (please complete the following information)**
+ - Component: [devkit (`physical_ai_av` package), a notebook under `notebooks/`, or the wiki docs]
+ - Install: `pip install physical_ai_av` — paste the installed package version
+ - HuggingFace: dataset license accepted / access granted for PhysicalAI-Autonomous-Vehicles? (yes/no); auth method used
+ - Data access: streaming vs local download; dataset split / clip / shard involved
+
+**Environment details**
+ - Operating System
+ - Python version and environment (Jupyter/Colab notebook or plain script)
+ - Key package versions: `physical_ai_av`, `huggingface_hub`
+ - Hardware only if relevant (this is a data devkit; a GPU is usually not required)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# .github/ISSUE_TEMPLATE/config.yml — Alpamayo family
+# Place this file at .github/ISSUE_TEMPLATE/config.yml in the repo root.
+#
+# GitHub Issues is reserved for code-level bugs, documentation
+# requests, and feature requests. Usage questions route via the contact_link
+# below; security reporting is handled by the repo's SECURITY.md — GitHub adds
+# its own "Report a security vulnerability" link automatically, so we do NOT
+# ship one here (avoids a duplicate security entry in the chooser).
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: 💬 Submit a question (usage, how-to)
+    url: https://forums.developer.nvidia.com/c/autonomous-vehicles/alpamayo/766
+    about: >
+      For usage questions and discussion, post on the Alpamayo NV Developer Forum category. GitHub Issues is reserved for code-level bugs, documentation fixes, and feature requests.

--- a/.github/ISSUE_TEMPLATE/documentation_request_template.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request_template.md
@@ -1,0 +1,35 @@
+---
+name: Documentation request
+about: Report incorrect or needed documentation for Alpamayo
+title: "[DOC]"
+labels: "? - Needs Triage, doc"
+assignees: 'yesfandiari'
+
+---
+
+## Report incorrect documentation
+
+**Location of incorrect documentation**
+Provide links and line numbers if applicable (e.g. the README, the [wiki](https://github.com/NVlabs/physical_ai_av/wiki), or a notebook under `notebooks/`).
+
+**Describe the problems or issues found in the documentation**
+A clear and concise description of what you found to be incorrect.
+
+**Steps taken to verify documentation is incorrect**
+List any steps you have taken:
+
+**Suggested fix for documentation**
+Detail proposed changes to fix the documentation if you have any.
+
+---
+
+## Report needed documentation
+
+**Report needed documentation**
+A clear and concise description of what documentation you believe is needed and why.
+
+**Describe the documentation you'd like**
+A clear and concise description of what you want to happen.
+
+**Steps taken to search for needed documentation**
+List any steps you have taken:

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for Alpamayo
+title: "[FEA]"
+labels: "? - Needs Triage, feature request"
+assignees: 'yesfandiari'
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I wish I could use the Physical AI AV devkit to do [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context, code examples, or references to existing implementations about the feature request here.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository contains a python developer kit and documentation (in the form of a [wiki](https://github.com/NVlabs/physical_ai_av/wiki) and interactive [notebooks](notebooks/)) for working with the [NVIDIA Physical AI Autonomous Vehicles Dataset](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles), one of the largest, most geographically diverse collections of multi-sensor data empowering AV researchers to build the next generation of Physical AI based end-to-end driving systems.
 
+## Support
+
+📣 **Usage questions and discussion about Physical AI AV dataset & devkit**: please join us on the [Alpamayo NV Developer Forum](https://forums.developer.nvidia.com/c/autonomous-vehicles/alpamayo/766).
+
+🐛 **Code-level bugs, documentation issues, and feature requests**: file a [GitHub issue](../../issues/new/choose) using the appropriate template (Bug report, Documentation request, or Feature request). The relevant NVIDIA responder is auto-assigned via the `assignees:` field on the template.
+
+🚨 **Security vulnerabilities**: please use [NVIDIA's Vulnerability Disclosure Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). Do not file security issues publicly here.
+
 ## Installation & Setup
 
 ```


### PR DESCRIPTION
## What this PR does

Adds the uniform NVIDIA AV support chooser to this repo (body text customized for **Physical AI AV dataset & devkit**; the chooser structure stays uniform across the Alpamayo family):

- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`; single **Submit a question** contact link → Alpamayo NV Developer Forum.
- `bug_report_template.md`, `documentation_request_template.md`, `feature_request_template.md` — `[BUG]` / `[DOC]` / `[FEA]` prefixes, auto-assign `yesfandiari`.
- `## Support` banner in the README (routing: Forum / GitHub Issues / NVIDIA VDP).

GitHub adds its own **Report a security vulnerability** link to the chooser automatically from the repo's `SECURITY.md`, so this PR intentionally ships no security link.

## Human-only checklist (after review)

- [ ] Grant `yesfandiari` **Triage** access (Settings → Collaborators) — GitHub silently drops auto-assignment if the user isn't a collaborator.
- [ ] Review + merge this PR.
- [ ] Visit [`/issues/new/choose`](https://github.com/NVlabs/physical_ai_av/issues/new/choose) and confirm the 3 templates + **Submit a question** + the auto-added **Report a security vulnerability** link appear.
- [ ] File a test issue → confirm `yesfandiari` is auto-notified → close it.

## Banner placement

Placed just above `## Installation & Setup`. Position is the repo owner's call — move it if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
